### PR TITLE
Revert "Fix the module path (after forking it)"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	smbios "github.com/xaionaro-facebook/go-dmidecode"
+	smbios "github.com/fenglyu/go-dmidecode"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xaionaro-facebook/go-dmidecode
+module github.com/fenglyu/go-dmidecode
 
 go 1.13
 


### PR DESCRIPTION
When I created PR https://github.com/fenglyu/go-dmidecode/pull/1 I did that from the main branch of my repository. And shortly before the PR was merged I introduced a problem there: I changed the package path to use my fork instead of the upstream repository. Reverting this changes. Sorry for this.